### PR TITLE
Fix getting account details in userscript

### DIFF
--- a/userscript/Steam_Community_Mobile_Trade_Confirmations.user.js
+++ b/userscript/Steam_Community_Mobile_Trade_Confirmations.user.js
@@ -145,7 +145,7 @@ function getAccountDetails() {
 			let result = await gmGet('https://steamcommunity.com');
 
 			let steamId = result.responseText.match(/g_steamID = "(\d+)";/);
-			let accountName = result.responseText.match(/<span class="[^"]*persona[^"]*">([^<]+)<\/span>/);
+			let accountName = result.responseText.match(/<span class="[^"]*account_name[^"]*">([^<]+)<\/span>/);
 			if (!steamId || !accountName) {
 				return resolve(null);
 			}


### PR DESCRIPTION
For now, userscript can not parse an account name and the confirmation page renders a 'Sign in to steamcommunity.com before attempting to access this page.' warning.